### PR TITLE
Fix login page infinite refresh loop

### DIFF
--- a/frontend/src/api/cookieClient.js
+++ b/frontend/src/api/cookieClient.js
@@ -81,12 +81,16 @@ apiClient.interceptors.response.use(
 
       // Try to refresh the token
       try {
-        await apiClient.post('/auth/cookie/refresh/');
+        await apiClient.post('/auth/refresh/');
         // Retry original request
         return apiClient(originalRequest);
       } catch (refreshError) {
-        // Refresh failed, redirect to login
-        window.location.href = '/login';
+        // Refresh failed, redirect to login only if not already on login page
+        if (!window.location.pathname.includes('/login')) {
+          window.location.href = '/login';
+        }
+        // Re-throw the error so the calling code can handle it
+        return Promise.reject(refreshError);
       }
     }
 

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -17,8 +17,13 @@ export function AuthProvider({ children }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
 
   // Check if user is already authenticated on mount
+  // Skip on login page to avoid unnecessary API calls
   useEffect(() => {
-    checkAuth()
+    if (!window.location.pathname.includes('/login')) {
+      checkAuth()
+    } else {
+      setLoading(false)
+    }
   }, [])
 
   const checkAuth = async () => {


### PR DESCRIPTION
Fixes the login page continuously refreshing by:
- Correcting the refresh token endpoint URL
- Preventing redirect loops when already on login page
- Skipping unnecessary auth checks on login page