### PR TITLE
Fix authentication persistence on page refresh

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -157,7 +157,7 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'utils.authentication.CookieJWTAuthentication',  # Use our custom cookie auth
         'rest_framework.authentication.SessionAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -29,7 +29,8 @@ export function AuthProvider({ children }) {
   const checkAuth = async () => {
     try {
       const response = await apiClient.get('/auth/me/')
-      setUser(response.data)
+      const userData = response.data.user || response.data
+      setUser(userData)
       setIsAuthenticated(true)
     } catch (error) {
       setUser(null)
@@ -51,8 +52,6 @@ export function AuthProvider({ children }) {
       })
 
       const userData = response.data.user || response.data
-      console.log('Login response:', response.data)
-      console.log('User data:', userData)
       setUser(userData)
       setIsAuthenticated(true)
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -17,21 +17,15 @@ export default function Login() {
 
     try {
       const result = await login(username, password)
-      console.log('Login result:', result)
-      console.log('User role:', result.user?.role)
 
       // Redirect based on user role
       if (result.user.role === 'admin' || result.user.role === 'staff') {
-        console.log('Redirecting to dashboard')
         navigate('/dashboard')
       } else if (result.user.role === 'student') {
-        console.log('Redirecting to student portal')
         navigate('/student-portal')
       } else if (result.user.role === 'guardian' || result.user.role === 'parent') {
-        console.log('Redirecting to parent portal')
         navigate('/parent-portal')
       } else {
-        console.log('Redirecting to dashboard (default)')
         navigate('/dashboard')
       }
     } catch (err) {


### PR DESCRIPTION
Users can now stay logged in when refreshing the page. The fix configures Django to use CookieJWTAuthentication which reads JWT tokens from httpOnly cookies instead of headers.